### PR TITLE
More info for outstanding maintenance.

### DIFF
--- a/src/site.rkt
+++ b/src/site.rkt
@@ -638,7 +638,7 @@
                     ,(~a (- (package-last-updated pkg))))
               ,@(maybe-splice
                  (< (- now (package-last-updated pkg)) recent-seconds)
-                 `(p (span ((class "label label-info")) "New")))
+                 (label-p "label-info" "New"))
               ,@(maybe-splice
                  (> 0 todokey)
                  (label-p (if (< todokey 5)
@@ -647,7 +647,7 @@
           (td (h2 ,(package-link (package-name pkg)))
               ,(authors-list (package-authors pkg)))
           (td (p ,(if (string=? "" (package-description pkg))
-                      `(span ((class "label-warning")) "This package needs a description")
+                      `(span ((class "label label-warning")) "This package needs a description")
                       (package-description pkg)))
               ,(if (not (or has-docs? has-readme?))
                    (label-p "label-warning" "This package needs documentation")
@@ -671,7 +671,7 @@
   (values (reverse pkg-rows) num-todos))
 
 (define (label-p cls txt)
-  `(p (span ((class ,cls)) ,txt)))
+  `(p (span ((class ,(string-append "label " cls))) ,txt)))
 
 (define (build-status-td pkg)
   ;; Build the index page cell for summarizing a package's build status.

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -638,30 +638,40 @@
                     ,(~a (- (package-last-updated pkg))))
               ,@(maybe-splice
                  (< (- now (package-last-updated pkg)) recent-seconds)
-                 `(span ((class "label label-info")) "New")))
+                 `(p (span ((class "label label-info")) "New")))
+              ,@(maybe-splice
+                 (> 0 todokey)
+                 (label-p (if (< todokey 5)
+                              "label-warning"
+                              "label-danger") "Todo")))
           (td (h2 ,(package-link (package-name pkg)))
               ,(authors-list (package-authors pkg)))
-          (td (p ,(package-description pkg))
-              ,@(maybe-splice
-                 (or has-docs? has-readme?)
-                 `(div
-                   (span ((class "doctags-label")) "Docs: ")
-                   ,(doc-links (package-docs pkg))
-                   ,@(maybe-splice has-readme?
-                                   " "
-                                   `(a ((href ,(package-readme-url pkg)))
-                                       "README"))))
-              ,@(maybe-splice
-                 has-tags?
-                 `(div
-                   (span ((class "doctags-label")) "Tags: ")
-                   ,(tag-links (package-tags pkg)))))
+          (td (p ,(if (string=? "" (package-description pkg))
+                      `(span ((class "label-warning")) "This package needs a description")
+                      (package-description pkg)))
+              ,(if (not (or has-docs? has-readme?))
+                   (label-p "label-warning" "This package needs documentation")
+                   `(div
+                     (span ((class "doctags-label")) "Docs: ")
+                     ,(doc-links (package-docs pkg))
+                     ,@(maybe-splice has-readme?
+                                     " "
+                                     `(a ((href ,(package-readme-url pkg)))
+                                         "README"))))
+              ,(if (not has-tags?)
+                   (label-p "label-warning" "This package needs tags")
+                   `(div
+                     (span ((class "doctags-label")) "Tags: ")
+                     ,(tag-links (package-tags pkg)))))
           ,(build-status-td pkg)
           (td ((style "display: none")) ,(number->string todokey))))
       (values (cons row-xexp pkg-rows)
               (+ num-todos (min todokey 1)))))
   ;; for/fold reverses pkg-rows, so un-reverse before returning.
   (values (reverse pkg-rows) num-todos))
+
+(define (label-p cls txt)
+  `(p (span ((class ,cls)) ,txt)))
 
 (define (build-status-td pkg)
   ;; Build the index page cell for summarizing a package's build status.

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -623,10 +623,12 @@
       (define has-docs? (pair? (package-docs pkg)))
       (define has-readme? (pair? (package-readme-url pkg)))
       (define has-tags? (pair? (package-tags pkg)))
+      (define has-desc? (not (string=? "" (package-description pkg))))
       (define todokey
-        (cond [(package-build-failure-log pkg) 4]
-              [(package-build-test-failure-log pkg) 3]
-              [(not (or has-docs? has-readme?)) 2]
+        (cond [(package-build-failure-log pkg) 5]
+              [(package-build-test-failure-log pkg) 4]
+              [(not (or has-docs? has-readme?)) 3]
+              [(not has-desc?) 2]
               [(not has-tags?) 1]
               [else 0]))
       (define row-xexp


### PR DESCRIPTION
This pull request modifies the package table on the package index home page so that any outstanding todos (such as missing descriptions, docs, or tags) are represented by a yellow warning label. It also adds a "Todo" label to the left-most column of the table which is yellow or red depending on the overall severity of that package's outstanding maintenance. Below is an example screenshot demonstrating how the table should look after merging this pull request.

![pkg-todo-alert-preview](https://user-images.githubusercontent.com/17788975/28423169-547a177c-6d38-11e7-8db0-98ce20cf18a8.png)

As with my previous pull request, I wasn't able to get the HTML generation working on my machine, so there may be minor errors in the code which generates the HTML X-expression. 