### PR TITLE
Packages now display docs for packages which imply them. 

### DIFF
--- a/src/site.rkt
+++ b/src/site.rkt
@@ -614,9 +614,10 @@
      ,@pkg-rows)))
 
 (define (get-implied-docs pkg)
-  (let* ([implied-names (package-implies pkg)]
-         [implied-pkgs (package-batch-detail implied-names)])
-    (map package-docs implied-pkgs)))
+  (define implied-names (package-implies pkg))
+  (for/fold ([out empty])
+            ([implied-pkg (package-batch-detail implied-names)])
+    (append out (package-docs implied-pkg))))
 
 (define (build-pkg-rows/num-todos package-names)
   ;; Builds the list of rows in the package table as an x-exp.
@@ -627,12 +628,7 @@
   (define-values (pkg-rows num-todos)
     (for/fold ([pkg-rows null] [num-todos 0])
               ([pkg (package-batch-detail package-names)])
-      (define pkg-docs
-        (let ([implied-docs (get-implied-docs pkg)]
-              [pkg-docs (package-docs pkg)])
-          (if (null? pkg-docs)
-              implied-docs
-              (append pkg-docs implied-docs))))
+      (define pkg-docs (append (package-docs pkg) (get-implied-docs pkg)))
       (define has-docs? (pair? pkg-docs))
       (define has-readme? (pair? (package-readme-url pkg)))
       (define has-tags? (pair? (package-tags pkg)))

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -553,7 +553,7 @@
       "N/A"))
 
 (define (get-implied-docs pkg)
-  (define implied-names (package-implies pkg))
+  (define implied-names (map string->symbol (package-implies pkg)))
   (append-map package-docs (package-batch-detail implied-names)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -552,6 +552,10 @@
       (string-append (date->string (seconds->date utc #f) #t) " (UTC)")
       "N/A"))
 
+(define (get-implied-docs pkg)
+  (define implied-names (package-implies pkg))
+  (append-map package-docs (package-batch-detail implied-names)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Package hashtable getters.
 ;; TODO factor this stuff out into a proper data structure
@@ -612,12 +616,6 @@
                               (div ((class "alert alert-info"))
                                    "No packages found."))))
      ,@pkg-rows)))
-
-(define (get-implied-docs pkg)
-  (define implied-names (package-implies pkg))
-  (for/fold ([out empty])
-            ([implied-pkg (package-batch-detail implied-names)])
-    (append out (package-docs implied-pkg))))
 
 (define (build-pkg-rows/num-todos package-names)
   ;; Builds the list of rows in the package table as an x-exp.

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -622,11 +622,12 @@
   ;; Builds the list of rows in the package table as an x-exp.
   ;; Also returns the total number of non-zero todo keys,
   ;; representing packages with outstanding build errors or
-  ;; failing tests, or which are missing docs or tags.                    
+  ;; failing tests, or which are missing docs or tags.
   (define now (/ (current-inexact-milliseconds) 1000))
   (define-values (pkg-rows num-todos)
     (for/fold ([pkg-rows null] [num-todos 0])
               ([pkg (package-batch-detail package-names)])
+      ;; TODO: list of package docs is actually NOT right data type?
       (define pkg-docs
         (let ([implied-docs (get-implied-docs)]
               [pkg-docs (package-docs pkg)])
@@ -651,7 +652,12 @@
                     ,(~a (- (package-last-updated pkg))))
               ,@(maybe-splice
                  (< (- now (package-last-updated pkg)) recent-seconds)
-                 (label-p "label-info" "New")))
+                 (label-p "label-info" "New"))
+              ,@(maybe-splice
+                 (> 0 todokey)
+                 (label-p (if (< todokey 5)
+                              "label-warning"
+                              "label-danger") "Todo")))
           (td (h2 ,(package-link (package-name pkg)))
               ,(authors-list (package-authors pkg)))
           (td (p ,(if (string=? "" (package-description pkg))

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -638,7 +638,7 @@
                     ,(~a (- (package-last-updated pkg))))
               ,@(maybe-splice
                  (< (- now (package-last-updated pkg)) recent-seconds)
-                 `(p (span ((class "label label-info")) "New")))
+                 (label-p "label-info" "New"))
               ,@(maybe-splice
                  (> 0 todokey)
                  (label-p (if (< todokey 5)
@@ -647,7 +647,7 @@
           (td (h2 ,(package-link (package-name pkg)))
               ,(authors-list (package-authors pkg)))
           (td (p ,(if (string=? "" (package-description pkg))
-                      `(span ((class "label-warning")) "This package needs a description")
+                      `(span ((class "label label-warning")) "This package needs a description")
                       (package-description pkg)))
               ,(if (not (or has-docs? has-readme?))
                    (label-p "label-warning" "This package needs documentation")
@@ -671,7 +671,7 @@
   (values (reverse pkg-rows) num-todos))
 
 (define (label-p cls txt)
-  `(p (span ((class ,cls)) ,txt)))
+  `(p (span ((class ,(string-append "label " cls))) ,txt)))
 
 (define (build-status-td pkg)
   ;; Build the index page cell for summarizing a package's build status.

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -638,30 +638,40 @@
                     ,(~a (- (package-last-updated pkg))))
               ,@(maybe-splice
                  (< (- now (package-last-updated pkg)) recent-seconds)
-                 `(span ((class "label label-info")) "New")))
+                 `(p (span ((class "label label-info")) "New")))
+              ,@(maybe-splice
+                 (> 0 todokey)
+                 (label-p (if (< todokey 5)
+                              "label-warning"
+                              "label-danger") "Todo")))
           (td (h2 ,(package-link (package-name pkg)))
               ,(authors-list (package-authors pkg)))
-          (td (p ,(package-description pkg))
-              ,@(maybe-splice
-                 (or has-docs? has-readme?)
-                 `(div
-                   (span ((class "doctags-label")) "Docs: ")
-                   ,(doc-links (package-docs pkg))
-                   ,@(maybe-splice has-readme?
-                                   " "
-                                   `(a ((href ,(package-readme-url pkg)))
-                                       "README"))))
-              ,@(maybe-splice
-                 has-tags?
-                 `(div
-                   (span ((class "doctags-label")) "Tags: ")
-                   ,(tag-links (package-tags pkg)))))
+          (td (p ,(if (string=? "" (package-description pkg))
+                      `(span ((class "label-warning")) "This package needs a description")
+                      (package-description pkg)))
+              ,(if (not (or has-docs? has-readme?))
+                   (label-p "label-warning" "This package needs documentation")
+                   `(div
+                     (span ((class "doctags-label")) "Docs: ")
+                     ,(doc-links (package-docs pkg))
+                     ,@(maybe-splice has-readme?
+                                     " "
+                                     `(a ((href ,(package-readme-url pkg)))
+                                         "README"))))
+              ,(if (not has-tags?)
+                   (label-p "label-warning" "This package needs tags")
+                   `(div
+                     (span ((class "doctags-label")) "Tags: ")
+                     ,(tag-links (package-tags pkg)))))
           ,(build-status-td pkg)
           (td ((style "display: none")) ,(number->string todokey))))
       (values (cons row-xexp pkg-rows)
               (+ num-todos (min todokey 1)))))
   ;; for/fold reverses pkg-rows, so un-reverse before returning.
   (values (reverse pkg-rows) num-todos))
+
+(define (label-p cls txt)
+  `(p (span ((class ,cls)) ,txt)))
 
 (define (build-status-td pkg)
   ;; Build the index page cell for summarizing a package's build status.

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -627,7 +627,6 @@
   (define-values (pkg-rows num-todos)
     (for/fold ([pkg-rows null] [num-todos 0])
               ([pkg (package-batch-detail package-names)])
-      ;; TODO: list of package docs is actually NOT right data type?
       (define pkg-docs
         (let ([implied-docs (get-implied-docs)]
               [pkg-docs (package-docs pkg)])

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -623,10 +623,12 @@
       (define has-docs? (pair? (package-docs pkg)))
       (define has-readme? (pair? (package-readme-url pkg)))
       (define has-tags? (pair? (package-tags pkg)))
+      (define has-desc? (not (string=? "" (package-description pkg))))
       (define todokey
-        (cond [(package-build-failure-log pkg) 4]
-              [(package-build-test-failure-log pkg) 3]
-              [(not (or has-docs? has-readme?)) 2]
+        (cond [(package-build-failure-log pkg) 5]
+              [(package-build-test-failure-log pkg) 4]
+              [(not (or has-docs? has-readme?)) 3]
+              [(not has-desc?) 2]
               [(not has-tags?) 1]
               [else 0]))
       (define row-xexp


### PR DESCRIPTION
This pull request alters the behavior of the package summary table such that packages will display links to the docs of packages which imply them. For example, the package `gui` infers its docs from the package `gui-doc`, so on the live version of the package table `gui` and `gui-doc` will always display the same list of documentation links.

The package `gui-lib`, however, is not able to infer its relationship to the `gui` or `gui-doc` packages, so it still incorrectly complains that it needs documentation. With these changes, `gui-lib` will display the docs of `gui`, which gives us the desirable behavior of `gui`, `gui-doc`, and `gui-lib` all displaying the same set of documentation links.

As with my previous pull requests, I'm unable to test these changes locally, so this pull request is contains my best effort at "mentally debugging" the new feature. It would be a good idea to test this change in isolation before pushing to the live server.