### PR TITLE
Remove colon to ensure label consistency

### DIFF
--- a/src/site.rkt
+++ b/src/site.rkt
@@ -335,7 +335,7 @@
                                   (role "form"))
                             ,(form-group 2 2 (label "email" "Email address")
                                          0 5 (email-input "email"))
-                            ,(form-group 2 2 (label "password" "Password:")
+                            ,(form-group 2 2 (label "password" "Password")
                                          0 5 (password-input "password"))
                             ,(form-group 4 5
                                          `(a ((href ,(embed-url (lambda (req) (register-form)))))


### PR DESCRIPTION
For the two labels to be consistent, either (a) the colon after
"Password" should be removed, as done here, or (b) a colon should be
added after the other label text ("Email address"). In this commit, I
opt for option (a), though (b) would also be reasonable.