### PR TITLE
Feat: prioritize search result

### DIFF
--- a/src/packages.rkt
+++ b/src/packages.rkt
@@ -290,20 +290,35 @@
                              ;; to do this at package save time, but this will do for now.
                              (pkg->searchable-text pkg)))))
 
+;; prioritize-search :: string? (listof symbol?) -> (listof symbol?)
+;; Precondition: names are sorted ascendingly
+;; Postcondition: names are reordered so that exact match is prioritized first
+;;   followed by those whose prefix matches the search text,
+;;   followed by those that contain the search text,
+;;   followed by other results
+(define (prioritize-search text names)
+  (match-define-values (prefixing non-prefixing)
+    (partition (λ (name) (string-prefix? (symbol->string name) text)) names))
+  (match-define-values (containing non-containing)
+    (partition (λ (name) (string-contains? (symbol->string name) text)) non-prefixing))
+  (append prefixing containing non-containing))
+
 (define (package-search text tags)
   (define res (map (lambda (r) (regexp (regexp-quote r #f))) (string-split text)))
   (define packages (manager-rpc 'packages))
-  (sort-package-names
-   (filter (lambda (package-name)
-             (define pkg (hash-ref packages package-name))
-             (andmap (package-text-matches? pkg) res))
-           (hash-keys
-            (for/fold ((ps packages)) ((tag-spec tags))
-              (match-define (list tag-name include?) tag-spec)
-              (for/hash (((package-name pkg) (in-hash ps))
-                         #:when (and (not (tombstone? pkg))
-                                     ((if include? values not) (@ref (@ pkg search-terms) tag-name))))
-                (values package-name pkg)))))))
+  (prioritize-search
+   text
+   (sort-package-names
+    (filter (lambda (package-name)
+              (define pkg (hash-ref packages package-name))
+              (andmap (package-text-matches? pkg) res))
+            (hash-keys
+             (for/fold ((ps packages)) ((tag-spec tags))
+               (match-define (list tag-name include?) tag-spec)
+               (for/hash (((package-name pkg) (in-hash ps))
+                          #:when (and (not (tombstone? pkg))
+                                      ((if include? values not) (@ref (@ pkg search-terms) tag-name))))
+                 (values package-name pkg))))))))
 
 (define (packages-jsexpr)
   (manager-rpc 'packages))

--- a/src/packages.rkt
+++ b/src/packages.rkt
@@ -290,7 +290,7 @@
                              ;; to do this at package save time, but this will do for now.
                              (pkg->searchable-text pkg)))))
 
-;; sort-package-names/priority :: (listof string?) (listof (cons/c symbol? package?))
+;; sort-package-names/priority :: (listof string?) (listof (cons/c symbol? package?)) -> (listof symbol?)
 ;; Rank packages by favoring those whose name prefixes or contains search strings
 ;; and whose description contains search strings
 (define (sort-package-names/priority text-list packages)
@@ -305,8 +305,9 @@
     (define priority
       (for/sum ([text (in-list text-list)])
         (cond
-          ;; NOTE: the exact match will be the first prefix lexicographically
-          ;; so there's no need to consider it
+          ;; NOTE: no need to check for string=? (the exact match)
+          ;; because it will also be a prefix, and will be
+          ;; weighted more due to its lexicographic order.
           [(string-prefix? pkg-name text) 100]
           [(string-contains? pkg-name text) 10]
           [(and pkg-desc (string-contains? pkg-desc text)) 1]


### PR DESCRIPTION
I have been frustrated by the the current result of package search because the first few results are often irrelevant to what I'm looking for, and I need to scroll in a long page to find the package that I actually want. 

This PR prioritizes the search result with 4 different priorities (lower rank comes before):

- If there's a package whose name exactly matches the search query, it will be prioritized with rank 1.
- If there's a package whose name is a prefix of the search query, it will be prioritized with rank 2.
- If there's a package whose name is a substring of the search query, it will be prioritized with rank 3.
- Otherwise, it will be prioritized with rank 4.

Note that it simply reorders the results. The number of results won't be affected by this PR.

Here are some examples:

Before:

<img width="469" alt="Screen Shot 2020-02-23 at 02 50 19" src="https://user-images.githubusercontent.com/9099577/75105966-752e5b00-55e7-11ea-89dc-10179d9e47dd.png">

After:

<img width="472" alt="Screen Shot 2020-02-23 at 02 50 07" src="https://user-images.githubusercontent.com/9099577/75105963-6fd11080-55e7-11ea-8840-891f6da8088e.png">

----

Before:

<img width="473" alt="Screen Shot 2020-02-23 at 02 49 24" src="https://user-images.githubusercontent.com/9099577/75106037-998a3780-55e7-11ea-9809-ce4c98589723.png">

After:

<img width="468" alt="Screen Shot 2020-02-23 at 02 49 14" src="https://user-images.githubusercontent.com/9099577/75106050-9db65500-55e7-11ea-81c7-b9539f7d3ec9.png">
