### PR TITLE
avoid 'failssucceeds' status

### DIFF
--- a/src/site.rkt
+++ b/src/site.rkt
@@ -702,8 +702,9 @@
                          [else "build_green"]))
 
   `(td ((class ,td-class))
-       ,@(for/list [(e (list (list failure-log-url "" "fails")
-                             (list success-log-url "" "succeeds")
+       ,@(for/list [(e (list (if failure-log-url
+                               (list failure-log-url "" "fails")
+                               (list success-log-url "" "succeeds"))
                              (list conflicts-log-url "; has " "conflicts")
                              (list dep-failure-log-url "; has " "dependency problems")
                              (list test-failure-log-url "; has " "failing tests")))]


### PR DESCRIPTION
If a package has a failure log and a success log, then ignore the
success and only show "fails" in the build summary.

fixes https://github.com/racket/pkg-build/issues/9

- - -

cc @mflatt

I think the only way that a package can fail & succeed is when pkg-build tries to generate documentation after a (single) package fails [pkg-build L938](https://github.com/racket/pkg-build/blob/master/main.rkt#L938-L940).

If that's not true, then maybe this is a bad solution because a success log could have useful info.

Also, maybe `pkg-build` should be changed instead to clean up the success files ~[L1007](https://github.com/racket/pkg-build/blob/master/main.rkt#L1007) ?