### PR TITLE
Description meta element

### DIFF
--- a/src/bootstrap.rkt
+++ b/src/bootstrap.rkt
@@ -53,6 +53,7 @@
                             #:code [code 200]
                             #:message [message #"Okay"]
                             #:body-class [body-class #f]
+                            #:description [description #f]
 			    .
 			    body-contents)
   (response/xexpr
@@ -65,6 +66,10 @@
 	   (meta ((http-equiv "X-UA-Compatible") (content "IE=edge")))
 	   (meta ((name "viewport") (content "width=device-width, initial-scale=1")))
 	   (title ,title)
+	   ,@(if (non-empty-string? description)
+		 `(meta ((name "description")
+			 (content ,description)))
+		 '())
 	   (link ((rel "stylesheet") (href ,(static "/bootstrap/css/bootstrap.min.css")) (type "text/css")))
 	   (link ((rel "stylesheet") (href ,(static "/jquery-ui.min.css")) (type "text/css")))
            (link ((rel "stylesheet") (href ,(static "/style.css")) (type "text/css")))

--- a/src/site.rkt
+++ b/src/site.rkt
@@ -830,6 +830,7 @@
       (let ((default-version (package-default-version pkg)))
         (bootstrap-response (~a package-name)
           #:title-element ""
+          #:description (package-description pkg)
           `(div ((class "jumbotron"))
                 (h1 ,(~a package-name))
                 (p ,(package-description pkg))


### PR DESCRIPTION
To give packages more visibility to web crawlers and other user agents that look for the description meta element, add package description information (if available).